### PR TITLE
fix: rename filetype rule `name` to `url` for yazi v25.12.29

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -215,16 +215,16 @@ rules = [
 	# { mime = "inode/empty", fg = "#eb6f92" },
 
 	# Special files
-	{ name = "*", is = "orphan", fg = "#191724", bg = "#eb6f92" },
-	{ name = "*", is = "exec"  , fg = "#9ccfd8" },
+	{ url = "*", is = "orphan", fg = "#191724", bg = "#eb6f92" },
+	{ url = "*", is = "exec"  , fg = "#9ccfd8" },
 
 	# Dummy files
-	{ name = "*", is = "dummy",  fg = "#191724", bg = "#eb6f92" },
-	{ name = "*/", is = "dummy", fg = "#191724", bg = "#eb6f92" },
+	{ url = "*", is = "dummy",  fg = "#191724", bg = "#eb6f92" },
+	{ url = "*/", is = "dummy", fg = "#191724", bg = "#eb6f92" },
 
 	# Fallback
-	{ name = "*",  fg = "#e0def4" },
-	{ name = "*/", fg = "#31748f" }
+	{ url = "*",  fg = "#e0def4" },
+	{ url = "*/", fg = "#31748f" }
 ]
 
 # : }}}


### PR DESCRIPTION
Fix #2 renaming filetype rule `name` to `url` for yazi v25.12.29